### PR TITLE
Fix target value in rutie_gen_localscore task

### DIFF
--- a/benchmark_tasks/rutie/rutie_gen_localscore.yaml
+++ b/benchmark_tasks/rutie/rutie_gen_localscore.yaml
@@ -5,3 +5,4 @@ tag:
 task: rutie_gen_localscore
 test_split: train
 fewshot_split: train
+doc_to_target: "{{'{target}'.format(target=outputs)}}"


### PR DESCRIPTION
Previously, the rutie_gen_localscore task used strings "RUTIE_TARGET_{idx}" instead of the true target values, which was suitable for general use. However, for local tasks, it is required to use true labels in order to immediately evaluate the correctness of the model outputs.

The behavior has been fixed in this Pull Request: now true labels are substituted instead of identifiers, which allows for a correct evaluation of the model in the local task.